### PR TITLE
Abbility to create instance resources from a template image

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ resource "softlayer_virtualserver" "my_server_1" {
     name = "my_server_1"
     domain = "example.com"
     ssh_keys = ["123456"]
+    image_type = "os_code"
     image = "DEBIAN_7_64"
     region = "ams01"
     public_network_speed = 10
@@ -77,7 +78,8 @@ resource "softlayer_virtualserver" "my_server_2" {
     name = "my_server_2"
     domain = "example.com"
     ssh_keys = ["123456", "${softlayer_ssh_key.test_key_1.id}"]
-    image = "CENTOS_6_64"
+    image_type = "template_id"
+    image = "dacf4db1-69a8-4bc8-bade-f51bd286c4df"
     region = "ams01"
     public_network_speed = 10
     cpu = 1


### PR DESCRIPTION
- Renamed `image` key on instance resources to `base_os_code`: `image` key is ambiguous, therefore, it is best to rename it explicitly as `base_os_code` as done in [packer-builder-softlayer](github.com/leonidlm/packer-builder-softlayer).
- New key `base_image_id`: Instance resources can be created from a template image, rather than a stock OS from Softlayer via `base_image_id`, like so:

``` terraform
provider "softlayer" {}

resource "softlayer_virtualserver" "test" {
    name  = "test"
    domain = "cool.io"
    base_image_id = "c4af5eg1-69a8-4dc7-b42e-f52bd1fdc4dc"
    region  = "dal01"
    public_network_speed = 10
    cpu = 1
    ram = 1024
}

```
- All modified code has been gofmt'd and it should be cherry-pickable
- README.md has been modified accordingly

Thanks for your efforts!
Cheers! :wine_glass: 
