### PR TITLE
Support for tags on created virtual guests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ resource "softlayer_virtualserver" "my_server_1" {
     public_network_speed = 10
     cpu = 1
     ram = 1024
+    tags = ["development", "experimental"]
 }
 
 # Virtual Server created with a mix of previously existing and \
@@ -87,6 +88,7 @@ resource "softlayer_virtualserver" "my_server_2" {
     public_network_speed = 10
     cpu = 1
     ram = 1024
+    tags = ["production", "www"]
 }
 ```
 


### PR DESCRIPTION
It is now possible to insert tags upon instance creation/update, like so:

```
resource "softlayer_virtualserver" "my_server_1" {
    name = "my_server_1"
    domain = "example.com"
    ssh_keys = ["123456"]
    image = "DEBIAN_7_64"
    region = "ams01"
    public_network_speed = 10
    cpu = 1
    ram = 1024
    tags = ["production", "another_tag"]
}
```

Changes on this branch:
- A new key `tags` has been added. It is interpreted as a list of `string`s and entirely optional.
- Documentation has been updated accordingly

I consider this feature necessary to have capabilities of performing resource classificaction on Softlayer already present on terraform :). 

Cheers! :wine_glass: 
Alejandro
