### PR TITLE
Remove underscores from example hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ resource "softlayer_ssh_key" "test_key_1" {
 
 # Virtual Server created with existing SSH Key already in SoftLayer \
 # inventory and not created using this Terraform template.
-resource "softlayer_virtualserver" "my_server_1" {
+resource "softlayer_virtualserver" "myserver1" {
     name = "my_server_1"
     domain = "example.com"
     ssh_keys = ["123456"]
@@ -77,7 +77,7 @@ resource "softlayer_virtualserver" "my_server_1" {
 
 # Virtual Server created with a mix of previously existing and \
 # Terraform created/managed resources.
-resource "softlayer_virtualserver" "my_server_2" {
+resource "softlayer_virtualserver" "myserver2" {
     name = "my_server_2"
     domain = "example.com"
     ssh_keys = ["123456", "${softlayer_ssh_key.test_key_1.id}"]


### PR DESCRIPTION
Softlayer does not allow underscores in hostnames:

```
Error applying plan:

1 error(s) occurred:

* softlayer_virtualserver.my_server_1: Error creating virtual server: The hostname and domain must be alphanumeric strings that may be separated by periods '.'.  The only other allowable special character is the dash '-'  However the special characters '.' and '-' may not be consecutive.  Each alphanumeric string separated by a period is considered a label.  Labels must begin and end with an alphanumeric character.  Each label cannot be solely comprised of digits and must be between 1-63 characters in length.  The last label, the TLD (top level domain) must be between 2-24 alphabetic characters.  The domain portion must consist of least one label followed by a period '.' then ending with the TLD label.  Combining the hostname, followed by a period '.', followed by the domain gives the FQDN (fully qualified domain name), which may not exceed 253 characters in total length.
```
