### PR TITLE
Set the provisioner connection host address

### DIFF
--- a/softlayer/resource_softlayer_virtualserver.go
+++ b/softlayer/resource_softlayer_virtualserver.go
@@ -255,6 +255,20 @@ func resourceSoftLayerVirtualserverRead(d *schema.ResourceData, meta interface{}
 	d.Set("has_public_ip", result.PrimaryIpAddress != "")
 	d.Set("ipv4_address", result.PrimaryIpAddress)
 	d.Set("ipv4_address_private", result.PrimaryBackendIpAddress)
+
+	connIpAddress := ""
+	if result.PrimaryIpAddress != "" {
+		connIpAddress = result.PrimaryIpAddress
+	} else {
+		connIpAddress = result.PrimaryBackendIpAddress
+	}
+
+	log.Printf("[INFO] Setting ConnInfo IP: %s", connIpAddress)
+	d.SetConnInfo(map[string]string{
+		"type": "ssh",
+		"host": connIpAddress,
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
Without setting the provisioner connection options, the `remote-exec`
provisioner uses a blank IP address, which results in a scp to localhost
rather than to the host that has just been created.
- Use the public IPv4 address, if available otherwise, use the private
  IPv4 address.
- Set the provisioner connection to ssh
